### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/cloudformation/sam.yaml
+++ b/cloudformation/sam.yaml
@@ -72,7 +72,7 @@ Resources:
       Description: "Lambda handler for travel plan bot"
       FunctionName: !Sub "${AWS::StackName}-LexBotHandler"
       CodeUri: ../lambda-functions/bot-handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 256
       Timeout: 20
       Handler: index.handler
@@ -95,7 +95,7 @@ Resources:
 #    Properties:
 #      Description: "Lambda function to update the user DDB table when cognito user signs up."
 #      CodeUri: ../lambda-functions/cognito-trigger
-#      Runtime: nodejs8.10
+#      Runtime: nodejs10.x
 #      MemorySize: 256
 #      Timeout: 20
 #      Handler: index.handler
@@ -115,7 +115,7 @@ Resources:
     Properties:
       Description: "Lambda function to load the plan catalog."
       CodeUri: ../lambda-functions/load-data
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 256
       Timeout: 20
       Handler: index.handler


### PR DESCRIPTION
CloudFormation templates in amazon-lex-customerservice-workshop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.